### PR TITLE
feat: Allow an optional config which suppresses noisy compiler warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,14 @@
                     "Tools-for-Solidity.Wake.port": {
                         "type": "integer",
                         "description": "Port on which Wake is listening. Overrides both Tools-for-Solidity.Wake.autoInstall and Tools-for-Solidity.Wake.pathToExecutable."
+                    },
+                    "Tools-for-Solidity.Wake.compiler.solc.ignoredWarnings": {
+                        "type": "array",
+                        "items": {
+                            "type": ["integer", "string"]
+                        },
+                        "default": [],
+                        "description": "Ignore warnings with these codes from the solc compiler"
                     }
                 }
             },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -232,6 +232,8 @@ export async function activate(context: vscode.ExtensionContext) {
     let installed: boolean = false;
     let cwd: string|undefined = undefined;
 
+    let solcIgnoredWarnings = extensionConfig.get<Array<integer|string>>('Wake.compiler.solc.ignoredWarnings', []);
+
     if (autoInstall && !pathToExecutable && !wakePort) {
         if (usePipx) {
             let pipxList;
@@ -371,6 +373,18 @@ export async function activate(context: vscode.ExtensionContext) {
     client.onNotification("textDocument/publishDiagnostics", (params) => {
         //outputChannel.appendLine(JSON.stringify(params));
         let diag = params as DiagnosticNotification;
+
+        // Do not show ignored warnings
+        diag.diagnostics = diag.diagnostics.filter((item) => {
+            if (
+                item.code &&
+                item.source === "Wake(solc)" &&
+                solcIgnoredWarnings.includes(Number.parseInt(item.code as string))
+            ) {
+                return false;
+            }
+            return true;
+        });
         onNotification(outputChannel, diag);
     });
 


### PR DESCRIPTION
Some warnings from the compiler are especially noisy when using the language server and they paint the entire contract.  This option allows the client to filter out some solc warnings which can be ignored by the LSP